### PR TITLE
Fix hashbang lines for scripts

### DIFF
--- a/combine_kreports.py
+++ b/combine_kreports.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 ################################################################
 #combine_kreports.py takes multiple kraken-style reports and combines
 #them into a single report file

--- a/extract_kraken_reads.py
+++ b/extract_kraken_reads.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 ######################################################################
 #extract_kraken_reads.py takes in a kraken-style output and kraken report
 #and a taxonomy level to extract reads matching that level

--- a/filter_bracken.out.py
+++ b/filter_bracken.out.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 #################################################################
 #filter_bracken_out.py allows users to filter Bracken output files 
 #Copyright (C) 2019 Jennifer Lu, jlu26@jhmi.edu

--- a/fix_unmapped.py
+++ b/fix_unmapped.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 ####################################################################
 #fix_unmapped.py analyzes a text file of accession IDs and maps them
 #to their respective taxonomy IDs given accession2taxid files. 

--- a/kreport2krona.py
+++ b/kreport2krona.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 ####################################################################
 #kreport2krona.py converts a Kraken-style report into Krona-compatible format
 #Copyright (C) 2019 Jennifer Lu, jlu26@jhmi.edu

--- a/make_kreport.py
+++ b/make_kreport.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 ######################################################################
 #make_kreport.py takes in the kraken output file and the make_ktaxonomy.py 
 #output file to generate a kraken report file 

--- a/make_ktaxonomy.py
+++ b/make_ktaxonomy.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 ######################################################################
 #make_taxonomy.py takes in three files: nodes.dmp, names.dmp, and 
 #seqid2taxid.map to create a condensed taxonomy file 


### PR DESCRIPTION
This little PR makes the `#!` lines of the script consistent, i.e. all:

```
#!/usr/bin/env python
```
