### PR TITLE
Change exit() to sys.exit() and add a check for empty fastq files

### DIFF
--- a/extract_kraken_reads.py
+++ b/extract_kraken_reads.py
@@ -183,7 +183,7 @@ def main():
     #Check input 
     if (len(args.output_file2) == 0) and (len(args.seq_file2) > 0):
         sys.stderr.write("Must specify second output file -o2 for paired input\n")
-        exit(1)
+        sys.exit(1)
 
     #Initialize taxids
     save_taxids = {}
@@ -196,7 +196,7 @@ def main():
         #check that report file exists
         if args.report_file == "": 
             sys.stderr.write(">> ERROR: --report not specified.")
-            exit(1)
+            sys.exit(1)
         sys.stdout.write(">> STEP 0: PARSING REPORT FILE %s\n" % args.report_file)
         #create tree and save nodes with taxids in the list 
         base_nodes = {} 
@@ -313,17 +313,20 @@ def main():
     else:
         s_file1 = open(seq_file1,'rt')
     first = s_file1.readline()
+    if len(first) == 0:
+        sys.stderr.write("ERROR: sequence file's first line is blank\n")
+        sys.exit(1)
     if first[0] == ">":
         filetype = "fasta"
     elif first[0] == "@":
         filetype = "fastq"
     else:
         sys.stderr.write("ERROR: sequence file must be FASTA or FASTQ\n")
-        exit(1)
+        sys.exit(1)
     s_file1.close()
     if filetype != 'fastq' and args.fastq_out:
         sys.stderr.write('ERROR: for FASTQ output, input file must be FASTQ\n')
-        exit(1)
+        sys.exit(1)
     ####ACTUALLY OPEN FILE
     if(seq_file1[-3:] == '.gz'):
         #Zipped Sequence Files
@@ -422,7 +425,7 @@ def main():
     #End of program
     time = strftime("%m-%d-%Y %H:%M:%S", gmtime())
     sys.stdout.write("PROGRAM END TIME: " + time + '\n')
-    exit(0)
+    sys.exit(0)
 
 #################################################################################
 

--- a/filter_bracken.out.py
+++ b/filter_bracken.out.py
@@ -57,13 +57,13 @@ def main():
     if len(args.t_include) == 0 and len(args.t_exclude) == 0:
         sys.stderr.write("User must include at least one taxonomy ID to include or exclude\n")
         sys.stderr.write("Please specify either --include or --exclude\n")
-        exit(1)
+        sys.exit(1)
     #CHECK#2: if both are specified, make sure none exists in both lists
     if len(args.t_include) > 0 and len(args.t_exclude) > 0:
         for val in args.t_include:
             if val in args.t_exclude:
                 sys.stderr.write("%s cannot be in include AND exclude lists\n" % val)
-                exit(1)
+                sys.exit(1)
     include = False
     exclude = False
     if len(args.t_include) > 0:
@@ -85,7 +85,7 @@ def main():
         if first:
             if line.split("\t") != ["name","taxonomy_id","taxonomy_lvl","kraken_assigned_reads","added_reads","new_est_reads","fraction_total_reads"]:
                 sys.stderr.write("\t%s not in Bracken output format\n" % args.in_file)
-                exit(1)
+                sys.exit(1)
             first = False
             firstline = line + "\n"
             continue

--- a/make_kreport.py
+++ b/make_kreport.py
@@ -191,7 +191,7 @@ def main():
     #End of program
     time = strftime("%m-%d-%Y %H:%M:%S", gmtime())
     sys.stdout.write("PROGRAM END TIME: " + time + '\n')
-    exit(0)
+    sys.exit(0)
 
 #################################################################################
 if __name__ == "__main__":

--- a/make_ktaxonomy.py
+++ b/make_ktaxonomy.py
@@ -243,7 +243,7 @@ def main():
     #End of program
     time = strftime("%m-%d-%Y %H:%M:%S", gmtime())
     sys.stdout.write("PROGRAM END TIME: " + time + '\n')
-    exit(0)
+    sys.exit(0)
 
 #################################################################################
 if __name__ == "__main__":


### PR DESCRIPTION
Hello, my workflow manager [SoS](https://github.com/vatlab/SoS/) was having a hard time catching exit signals from extract_kraken_reads.py, so hanging without going to the next step in my pipeline. I'm not sure exactly why, but [this](https://stackoverflow.com/questions/6501121/difference-between-exit-and-sys-exit-in-python) question on stackoverflow makes it seem that sys.exit() is preferred to exit(). I changed exit() to sys.exit() in extract_kraken_reads.py and now my pipeline is working smoothly. I'm happy to keep my own branch but thought you might want to pull the changes. I also added a minor file check to give a warning if the input fastq file was empty.