### PR TITLE
Fix merged nodes

### DIFF
--- a/make_ktaxonomy.py
+++ b/make_ktaxonomy.py
@@ -126,7 +126,7 @@ def main():
     # The outdated taxid has the same rank as the updated taxid
     with open(args.merged_file, 'r') as merged_f:
         for line in merged_f:
-            outdated_taxid, updated_taxid, *_ = line.split("\t|\t")
+            outdated_taxid, updated_taxid, *_ = [taxid.strip() for taxid in line.split("|")]
 
             rank = taxid2node[updated_taxid].level_rank
             taxid2node[outdated_taxid] = Tree(outdated_taxid, rank, parent=updated_taxid)


### PR DESCRIPTION
Fixes an issue that can occur when the taxonomy database is newer than the `kraken2` database. Sometimes taxid nodes get merged. The merged nodes are removed from `nodes.dmp` and noted in `merged.dmp`.

So if you've generated your `kraken2` results with [the latest pre-built databases](https://benlangmead.github.io/aws-indexes/k2), but have run `make_ktaxonomy.py` with a freshly downloaded taxonomy, `make_kreport.py` will fail because it finds taxids that are not in the taxonomy. 

This PR will add the obsolete taxid as a child of the updated taxid. This allows `make_kreport.py` to still run if the situation described above arises. 