### PR TITLE
Handle kreports with no root line

### DIFF
--- a/combine_kreports.py
+++ b/combine_kreports.py
@@ -216,7 +216,7 @@ def main():
                 continue
             #Tree Root 
             if taxid == '1': 
-                if count_samples == 1:
+                if root_node == -1:
                     root_node = Tree(name, taxid, level_num, 'R', 0,0)
                     taxid2node[taxid] = root_node 
                 root_node.add_reads(count_samples, all_reads, level_reads) 


### PR DESCRIPTION
Kraken2 outputs kraken reports without a "Root" line if all reads are unclassified. I have not tested the other Kraken versions.

This fixes an error where the tree is uninitialized because the first kreport file passed to `combine_kreports.py` contains only unclassified reads.